### PR TITLE
Fail when DiskPart compaction exits nonzero

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,28 @@ The script performs the following actions:
 
 - The script throws errors on missing admin rights, missing registry entries, missing ext4.vhdx file, or failed WSL shutdown.
 - When `fstrim` fails it logs a warning and continues.
+- A failed DiskPart compaction is reported for that distro without marking it
+  optimized. The remaining distros are still processed, and every result is
+  included in the summary. After the summary, any failed compaction raises an
+  aggregate error (`powershell.exe -File` exits with code 1); all-success runs
+  exit with code 0. DiskPart's native exit code is checked, not localized text.
+
+### Testing
+
+Run the regression tests from the repository root in Windows PowerShell 5.1:
+
+```powershell
+powershell.exe -NoProfile -File .\tests\Test-Compaction.ps1
+```
+
+No administrator rights or additional modules are needed. The tests execute
+the script's compaction loop and summary in isolated PowerShell processes,
+substitute DiskPart and Optimize-VHD, and use only disposable text files. They
+never enumerate distros, trim disks, shut down WSL, or compact a real VHDX.
+They verify native process exit handling, per-distro results, continuation,
+fallback and temporary-script cleanup, not physical VHD attachment or space
+reclamation. Small synthetic diagnostic files are retained at the printed
+temporary path.
 
 ### Misc
 

--- a/tests/Test-Compaction.ps1
+++ b/tests/Test-Compaction.ps1
@@ -1,0 +1,110 @@
+param([string]$SourcePath = (Join-Path $PSScriptRoot '..\wsl_compactor.ps1'))
+
+$ErrorActionPreference = 'Stop'
+$SourcePath = (Resolve-Path -LiteralPath $SourcePath).ProviderPath
+$fixture = Join-Path $PSScriptRoot 'compaction_fixture.ps1'
+$engine = Join-Path $PSHOME 'powershell.exe'
+if (-not (Test-Path -LiteralPath $engine)) { throw 'Run these tests in Windows PowerShell.' }
+$root = Join-Path ([IO.Path]::GetTempPath()) ('wsl-compact-tests-' + [guid]::NewGuid())
+$null = New-Item -ItemType Directory -Path $root
+$failures = New-Object 'System.Collections.Generic.List[string]'
+$cases = @(
+  @{ Name = 'success'; Exit = 0; Optimized = @($true); Native = @(0); Hyperv = 0 },
+  @{ Name = 'all_success'; Exit = 0; Optimized = @($true, $true); Native = @(0, 0); Hyperv = 0 },
+  @{ Name = 'failure'; Exit = 1; Optimized = @($false); Native = @(7); Hyperv = 0 },
+  @{ Name = 'signed_failure'; Exit = 1; Optimized = @($false); Native = @(-2147024809); Hyperv = 0 },
+  @{ Name = 'failure_then_success'; Exit = 1; Optimized = @($false, $true); Native = @(7, 0); Hyperv = 0 },
+  @{ Name = 'success_then_failure'; Exit = 1; Optimized = @($true, $false); Native = @(0, 7); Hyperv = 0 },
+  @{ Name = 'all_failed'; Exit = 1; Optimized = @($false, $false); Native = @(7, 9); Hyperv = 0 },
+  @{ Name = 'hyperv_success'; Exit = 0; Optimized = @($true); Native = @(); Hyperv = 1 },
+  @{ Name = 'fallback_success'; Exit = 0; Optimized = @($true); Native = @(0); Hyperv = 1 },
+  @{ Name = 'fallback_failure'; Exit = 1; Optimized = @($false); Native = @(7); Hyperv = 1 },
+  @{ Name = 'command_error'; Exit = 1; Optimized = @($false, $true); Native = @(0); Hyperv = 0 },
+  @{ Name = 'silent_failure'; Exit = 1; Optimized = @($false); Native = @(7); Hyperv = 0 },
+  @{ Name = 'localized_failure'; Exit = 1; Optimized = @($false); Native = @(7); Hyperv = 0 }
+)
+$runs = @(foreach ($case in $cases) {
+  foreach ($preference in @('Continue', 'Stop')) {
+    @{ Case = $case; Preference = $preference }
+  }
+})
+
+try {
+  foreach ($run in $runs) {
+    $case = $run.Case
+    $name = "$($case.Name)-$($run.Preference)"
+    $directory = Join-Path $root $name
+    $null = New-Item -ItemType Directory -Path $directory
+    $stdout = Join-Path $directory 'stdout.txt'
+    $stderr = Join-Path $directory 'stderr.txt'
+    $arguments = '-NoLogo -NoProfile -NonInteractive -File "{0}" -SourcePath "{1}" -ResultDirectory "{2}" -Scenario {3} -ErrorPreference {4}' -f (
+      $fixture, $SourcePath, $directory, $case.Name, $run.Preference
+    )
+    $start = New-Object System.Diagnostics.ProcessStartInfo($engine, $arguments)
+    $start.UseShellExecute = $false
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $start
+    $null = $process.Start()
+    $outputTask = $process.StandardOutput.ReadToEndAsync()
+    $errorTask = $process.StandardError.ReadToEndAsync()
+    try {
+      if (-not $process.WaitForExit(30000)) {
+        $process.Kill()
+        $process.WaitForExit()
+        throw 'Fixture exceeded 30 seconds.'
+      }
+      $output = $outputTask.GetAwaiter().GetResult()
+      $errorOutput = $errorTask.GetAwaiter().GetResult()
+      Set-Content -LiteralPath $stdout -Value $output -Encoding UTF8
+      Set-Content -LiteralPath $stderr -Value $errorOutput -Encoding UTF8
+      $result = Get-Content -LiteralPath (Join-Path $directory 'result.json') -Raw | ConvertFrom-Json
+      if ($result.ErrorPreference -ne $run.Preference) { throw 'Wrong error preference.' }
+      if ($process.ExitCode -ne $case.Exit) { throw "Wrong process exit: $($process.ExitCode)." }
+      if (@($result.Jobs).Count -ne $case.Optimized.Count) { throw 'Missing distro results.' }
+      for ($i = 0; $i -lt $case.Optimized.Count; $i++) {
+        if ($result.Jobs[$i].Optimized -isnot [bool] -or
+            $result.Jobs[$i].Optimized -ne $case.Optimized[$i]) {
+          throw "Wrong Optimized state for distro $i."
+        }
+        if ($null -eq $result.Jobs[$i].CurrentSize) { throw "Missing size for distro $i." }
+        if ($output -notmatch "Distro: fixture-$i") { throw "Missing summary for distro $i." }
+      }
+      if (($result.NativeExits -join ',') -ne ($case.Native -join ',')) { throw 'Wrong native exit sequence.' }
+      if (@($result.HypervCalls).Count -ne $case.Hyperv) { throw 'Wrong Hyper-V call count.' }
+      $expectedDiskpart = if ($case.Name -eq 'hyperv_success') { 0 } else { $case.Optimized.Count }
+      if (@($result.DiskpartCalls).Count -ne $expectedDiskpart) { throw 'Wrong DiskPart call count.' }
+      if (@($result.RemainingTemps).Count -ne 0) { throw 'Temporary script was not removed.' }
+      if ($case.Exit -ne 0 -and $output -match '(?m)^Done\.') { throw 'Failure reported as Done.' }
+      if ($case.Exit -eq 0 -and $output -notmatch '(?m)^Done\.') { throw 'Success summary missing.' }
+      if ($case.Exit -eq 0 -and -not [string]::IsNullOrWhiteSpace($errorOutput)) {
+        throw 'Unexpected successful-run stderr.'
+      }
+      if ($case.Exit -ne 0 -and $errorOutput -notmatch 'One or more distros did not compact successfully') {
+        throw 'Aggregate failure missing.'
+      }
+      if ($case.Optimized.Count -gt 1 -and $output -notmatch 'Total across all distros') {
+        throw 'Multi-distro total missing.'
+      }
+      Write-Host "PASS $name (Windows PowerShell $($result.Version), exit $($process.ExitCode))"
+    }
+    catch {
+      $failures.Add("${name}: $($_.Exception.Message)")
+      Write-Warning $failures[$failures.Count - 1]
+    }
+    finally {
+      if (-not $process.HasExited) {
+        $process.Kill()
+        $process.WaitForExit()
+      }
+      $process.Dispose()
+    }
+  }
+  if ($failures.Count) { throw "$($failures.Count) of $($runs.Count) cases failed. Evidence: $root" }
+  Write-Host "$($runs.Count) cases passed. Evidence: $root"
+}
+finally {
+  # Retain small synthetic logs for diagnosis; no real disk or WSL operations ran.
+  Write-Host "Fixture evidence: $root"
+}

--- a/tests/compaction_fixture.ps1
+++ b/tests/compaction_fixture.ps1
@@ -1,0 +1,121 @@
+param(
+  [Parameter(Mandatory = $true)][string]$SourcePath,
+  [Parameter(Mandatory = $true)][string]$ResultDirectory,
+  [Parameter(Mandatory = $true)][string]$Scenario,
+  [ValidateSet('Continue', 'Stop')][string]$ErrorPreference = 'Continue'
+)
+
+$ErrorActionPreference = 'Stop'
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+  $SourcePath, [ref]$tokens, [ref]$parseErrors
+)
+if ($parseErrors.Count) { throw 'The compactor did not parse.' }
+
+# Only the compaction loop and summary run; never admin, trim or shutdown code.
+$loops = @($ast.EndBlock.Statements | Where-Object {
+  $_ -is [System.Management.Automation.Language.ForEachStatementAst] -and
+  $_.Body.Statements[0] -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+  $_.Body.Statements[0].Left.Extent.Text -eq '$optimized'
+})
+if ($loops.Count -ne 1) { throw 'Expected exactly one compaction loop.' }
+$statements = @($ast.EndBlock.Statements | Where-Object {
+  $_.Extent.StartOffset -ge $loops[0].Extent.StartOffset
+})
+$body = [scriptblock]::Create(($statements | ForEach-Object { $_.Extent.Text }) -join "`n")
+$allowed = @('Write-Host', 'Write-Warning', 'Optimize-VHD', 'Set-Content',
+  'diskpart', 'ForEach-Object', 'Remove-Item', 'Add-Member', 'Get-Item', 'Where-Object')
+foreach ($command in $body.Ast.FindAll({
+  param($node) $node -is [System.Management.Automation.Language.CommandAst]
+}, $true)) {
+  if ($command.GetCommandName() -notin $allowed) {
+    throw "Unexpected fixture command: $($command.GetCommandName())"
+  }
+}
+
+$cases = @{
+  success = @(0)
+  all_success = @(0, 0)
+  failure = @(7)
+  signed_failure = @(-2147024809)
+  failure_then_success = @(7, 0)
+  success_then_failure = @(0, 7)
+  all_failed = @(7, 9)
+  hyperv_success = @(0)
+  fallback_success = @(0)
+  fallback_failure = @(7)
+  command_error = @(7, 0)
+  silent_failure = @(7)
+  localized_failure = @(7)
+}
+if (-not $cases.ContainsKey($Scenario)) { throw 'Unknown fixture scenario.' }
+$env:TEMP = $ResultDirectory
+$env:TMP = $ResultDirectory
+$diskpartCalls = New-Object 'System.Collections.Generic.List[string]'
+$hypervCalls = New-Object 'System.Collections.Generic.List[string]'
+$nativeExits = New-Object 'System.Collections.Generic.List[int]'
+$tempFiles = New-Object 'System.Collections.Generic.List[string]'
+$codes = @($cases[$Scenario])
+$jobs = @(for ($i = 0; $i -lt $codes.Count; $i++) {
+  $path = Join-Path $ResultDirectory "synthetic-$i.txt"
+  Set-Content -LiteralPath $path -Value 'Not a virtual disk.' -Encoding ASCII
+  [PSCustomObject]@{
+    Name = "fixture-$i"
+    Vhdx = $path
+    PrevSize = (Get-Item -LiteralPath $path).Length
+    ExitCode = $codes[$i]
+  }
+})
+$hypervAvailable = $Scenario -in @('hyperv_success', 'fallback_success', 'fallback_failure')
+$global:LASTEXITCODE = 42
+
+function Optimize-VHD {
+  [CmdletBinding()]
+  param([string]$Path, [string]$Mode)
+  $hypervCalls.Add($j.Name)
+  if ($Path -ne $j.Vhdx -or $Mode -ne 'Full') { throw 'Unexpected Hyper-V arguments.' }
+  if ($Scenario -ne 'hyperv_success') { throw 'Synthetic Hyper-V failure.' }
+}
+
+function diskpart {
+  param([string]$Mode, [string]$InputFile)
+  $diskpartCalls.Add($j.Name)
+  $tempFiles.Add($InputFile)
+  if ($Mode -ne '/s' -or (Split-Path $InputFile) -ne $ResultDirectory) {
+    throw 'Unexpected DiskPart arguments.'
+  }
+  if ($Scenario -eq 'command_error' -and $j.Name -eq 'fixture-0') {
+    throw 'Synthetic command exception.'
+  }
+  if ($Scenario -eq 'localized_failure') { 'Error de disco simulado.' }
+  elseif ($Scenario -ne 'silent_failure') { '100 percent' }
+  # A real harmless native process supplies LASTEXITCODE, not a mocked integer.
+  & "$env:SystemRoot\System32\cmd.exe" /d /c "exit $($j.ExitCode)"
+  $nativeExits.Add($LASTEXITCODE)
+}
+
+foreach ($name in @('diskpart', 'Optimize-VHD')) {
+  if ((Get-Command $name).CommandType -ne 'Function') {
+    throw "The destructive command '$name' is not intercepted."
+  }
+}
+
+try {
+  $ErrorActionPreference = $ErrorPreference
+  . $body
+}
+finally {
+  $ErrorActionPreference = 'Stop'
+  [PSCustomObject]@{
+    Version = $PSVersionTable.PSVersion.ToString()
+    ErrorPreference = $ErrorPreference
+    Jobs = @($jobs | Select-Object Name, Optimized, CurrentSize)
+    DiskpartCalls = @($diskpartCalls.ToArray())
+    HypervCalls = @($hypervCalls.ToArray())
+    NativeExits = @($nativeExits.ToArray())
+    RemainingTemps = @($tempFiles | Where-Object { Test-Path -LiteralPath $_ })
+  } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (
+    Join-Path $ResultDirectory 'result.json'
+  ) -Encoding UTF8
+}

--- a/wsl_compactor.ps1
+++ b/wsl_compactor.ps1
@@ -291,6 +291,10 @@ exit
           Write-Host $_
         }
       }
+      $diskpartExitCode = $LASTEXITCODE
+      if ($diskpartExitCode -ne 0) {
+        throw "DiskPart failed for '$($j.Name)' with exit code $diskpartExitCode."
+      }
       $optimized = $true
     }
     finally {

--- a/wsl_compactor.ps1
+++ b/wsl_compactor.ps1
@@ -297,6 +297,9 @@ exit
       }
       $optimized = $true
     }
+    catch {
+      Write-Warning $_.Exception.Message
+    }
     finally {
       Remove-Item $tempFile -ErrorAction SilentlyContinue
     }
@@ -338,7 +341,7 @@ if ($jobs.Count -gt 1) {
 }
 
 if ($jobs | Where-Object { -not $_.Optimized }) {
-  Write-Warning "`nOne or more distros did not compact successfully. See warnings above."
+  throw "One or more distros did not compact successfully. See warnings above."
 }
 else {
   Write-Host "`nDone." -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Capture DiskPart's native exit code immediately after its output pipeline;
  never mark a failed compaction as optimized.
- Handle failure per distro, preserve temporary-script cleanup, continue with
  the remaining distros, and include every result in the summary.
- Raise an aggregate error only after the summary when any compaction failed,
  so `powershell.exe -File` exits with code 1 instead of reporting success to
  automation. All-success runs still exit with code 0.
- Add reproducible Windows PowerShell 5.1 regression tests and document the
  failure/reporting behavior.

## Why

Native failures do not automatically become catchable errors in Windows
PowerShell 5.1. The explicit nonzero check remains necessary. DiskPart documents
scripted error codes unless `noerr` is used; the check does not depend on the
Windows display language:

https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/diskpart-scripts-and-examples

This follow-up addresses the maintainer's per-distro handling request. A
warning-only catch would continue correctly but finish with process exit 0;
the aggregate error retains machine-readable failure after the complete summary.

## Validation

Run from the repository root in Windows PowerShell:

```powershell
powershell.exe -NoProfile -File .\tests\Test-Compaction.ps1
```

- 26 cases passed on Windows PowerShell 5.1.26100.9278: 13 scenarios with both
  `Continue` and `Stop` error preferences.
- Covers success, all-success, single/signed-native failure, both mixed-lot
  orders, all-failed, Hyper-V success, fallback success/failure, command
  exception, empty output and localized output.
- Verifies actual child process exit codes, exact native exit sequences,
  per-distro state/size, complete summaries, fallback call counts, no false
  `Done`, and temporary-script removal.
- The same final suite against the previous PR head: 8 passed / 18 failed,
  detecting the premature abort. Against a warning-only variant: 8 passed /
  18 failed, detecting incorrect process exit 0.
- All three PowerShell files parse; `Test-ScriptFileInfo` passes for the
  compactor. Existing production CRLF is preserved; diff whitespace check passes.

The tests run the actual compaction loop and summary selected from the source
AST, with DiskPart and Optimize-VHD substituted. A harmless native `cmd.exe`
process supplies exit codes. They use disposable text files only and never
enumerate distros, run fstrim, shut down WSL or compact a real VHDX. They verify
control flow and reporting, not physical compaction, VHD detachment, space
reclamation or the packaged executable.
